### PR TITLE
user authentication package

### DIFF
--- a/auth/role.go
+++ b/auth/role.go
@@ -1,0 +1,205 @@
+package auth
+
+import (
+	"bytes"
+	"errors"
+	"regexp"
+	"strings"
+)
+
+var (
+	ErrResourceKeyEmpty  = errors.New("resource key is empty")
+	ErrInvalidPrivileges = errors.New("atleast one or atmost four privileges must be set")
+)
+
+type Priv struct {
+	c bool
+	r bool
+	u bool
+	d bool
+	k *ResourceKey
+}
+
+func NewPriv(k string, c bool, r bool, u bool, d bool) (*Priv, error) {
+	rk, e := NewKey(k)
+	if e != nil {
+		return nil, e
+	}
+
+	if !c && !r && !u && !d {
+		return nil, ErrInvalidPrivileges
+	}
+
+	return &Priv{
+		c: c,
+		r: r,
+		u: u,
+		d: d,
+		k: rk,
+	}, nil
+}
+
+func (p *Priv) String() string {
+	crud := ":c,r,u,d"
+	buf := bytes.NewBuffer(make([]byte, 0, len(p.k.key)+len(crud)))
+	buf.WriteString(p.k.key)
+	buf.WriteString(":")
+
+	prev := false
+	prevWrite := func(b bool, l string) {
+		if prev && b {
+			buf.WriteString(",")
+			buf.WriteString(l)
+		} else if b {
+			buf.WriteString(l)
+			prev = true
+		}
+	}
+	prevWrite(p.c, "c")
+	prevWrite(p.r, "r")
+	prevWrite(p.u, "u")
+	prevWrite(p.d, "d")
+
+	return buf.String()
+}
+
+func (p *Priv) MarshalText() ([]byte, error) {
+	return []byte(p.String()), nil
+}
+
+//nolint:cyclop
+func (p *Priv) UnmarshalText(text []byte) error {
+	t := string(text)
+	t = strings.TrimSpace(t)
+
+	if !strings.Contains(t, ":") {
+		return ErrResourceKeyEmpty
+	}
+
+	s := strings.Split(t, ":")
+
+	privs := strings.Split(s[1], ",")
+	if len(privs) == 0 || len(privs) > 4 {
+		return ErrInvalidPrivileges
+	}
+
+	k, err := NewKey(s[0])
+	if err != nil {
+		return err
+	}
+
+	p.k = k
+
+	for _, priv := range privs {
+		switch priv {
+		case "c":
+			p.c = true
+		case "r":
+			p.r = true
+		case "u":
+			p.u = true
+		case "d":
+			p.d = true
+		default:
+			return ErrInvalidPrivileges
+		}
+	}
+
+	return nil
+}
+
+func (p *Priv) Read(key string) bool {
+	return p.k.Match(key) && p.r
+}
+
+func (p *Priv) Write(key string) bool {
+	return p.k.Match(key) && p.c && p.u && p.d
+}
+
+func (p *Priv) Update(key string) bool {
+	return p.k.Match(key) && p.u
+}
+
+func (p *Priv) Create(key string) bool {
+	return p.k.Match(key) && p.c
+}
+
+func (p *Priv) Delete(key string) bool {
+	return p.k.Match(key) && p.d
+}
+
+type ResourceKey struct {
+	key string
+	re  *regexp.Regexp
+}
+
+func NewKey(key string) (*ResourceKey, error) {
+	re, err := regexp.Compile(key)
+	if err != nil {
+		return nil, err
+	}
+
+	return &ResourceKey{
+		key: key,
+		re:  re,
+	}, nil
+}
+
+func (r *ResourceKey) Match(key string) bool {
+	return r.re.MatchString(key)
+}
+
+type Role struct {
+	Name       string  `json:"name"`
+	Privileges []*Priv `json:"privileges"`
+}
+
+func (r *Role) Read(key string) bool {
+	for _, priv := range r.Privileges {
+		if priv.Read(key) {
+			return true
+		}
+	}
+
+	return false
+}
+
+func (r *Role) Write(key string) bool {
+	for _, priv := range r.Privileges {
+		if priv.Write(key) {
+			return true
+		}
+	}
+
+	return false
+}
+
+func (r *Role) Create(key string) bool {
+	for _, priv := range r.Privileges {
+		if priv.Create(key) {
+			return true
+		}
+	}
+
+	return false
+}
+
+func (r *Role) Update(key string) bool {
+	for _, priv := range r.Privileges {
+		if priv.Update(key) {
+			return true
+		}
+	}
+
+	return false
+}
+
+func (r *Role) Delete(key string) bool {
+	for _, priv := range r.Privileges {
+		if priv.Delete(key) {
+			return true
+		}
+	}
+
+	return false
+}

--- a/auth/role_test.go
+++ b/auth/role_test.go
@@ -1,0 +1,100 @@
+package auth_test
+
+import (
+	"testing"
+
+	"github.com/project-safari/zebra/auth"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestKey(t *testing.T) {
+	t.Parallel()
+
+	assert := assert.New(t)
+	k, e := auth.NewKey("a/b/c")
+	assert.Nil(e)
+	assert.NotNil(k)
+	assert.True(k.Match("a/b/c"))
+	assert.True(k.Match("a/b/c/d"))
+	assert.False(k.Match("/b/c/d"))
+
+	k, e = auth.NewKey("*")
+	assert.NotNil(e)
+	assert.Nil(k)
+
+	k, e = auth.NewKey("a/[a-z0-9]*/c")
+	assert.Nil(e)
+	assert.NotNil(k)
+	assert.True(k.Match("a/b/c"))
+	assert.True(k.Match("a/k/c"))
+	assert.False(k.Match("/b/c/d"))
+}
+
+//nolint:funlen
+func TestPriv(t *testing.T) {
+	t.Parallel()
+
+	assert := assert.New(t)
+	p, e := auth.NewPriv("*", false, false, false, false)
+	assert.Nil(p)
+	assert.NotNil(e)
+	p, e = auth.NewPriv("a/b/c", false, false, false, false)
+	assert.Nil(p)
+	assert.NotNil(e)
+
+	p, e = auth.NewPriv("a/b/c", true, false, false, false)
+	assert.Nil(e)
+	assert.NotNil(p)
+	assert.Equal("a/b/c:c", p.String())
+	b, e := p.MarshalText()
+	assert.Nil(e)
+	assert.Equal(p.String(), string(b))
+	assert.True(p.Create("a/b/c"))
+	assert.False(p.Read("a/b/c"))
+	assert.False(p.Update("a/b/c"))
+	assert.False(p.Delete("a/b/c"))
+	assert.False(p.Write("a/b/c"))
+
+	assert.Nil(p.UnmarshalText([]byte("c/d/e:c,r,u,d")))
+	assert.Equal("c/d/e:c,r,u,d", p.String())
+	assert.NotNil(p.UnmarshalText([]byte("*:c,r,u,d")))
+	assert.NotNil(p.UnmarshalText([]byte("c,r,u,d")))
+	assert.NotNil(p.UnmarshalText([]byte("a/b/c")))
+	assert.NotNil(p.UnmarshalText([]byte("a/b/c:xxx")))
+	assert.NotNil(p.UnmarshalText([]byte("a/b/c:c,r,u,d,e,f")))
+
+	p, e = auth.NewPriv("a/b/c", true, true, false, false)
+	assert.Nil(e)
+	assert.NotNil(p)
+	assert.Equal("a/b/c:c,r", p.String())
+	assert.True(p.Create("a/b/c"))
+	assert.True(p.Read("a/b/c"))
+	assert.False(p.Update("a/b/c"))
+	assert.False(p.Delete("a/b/c"))
+	assert.False(p.Write("a/b/c"))
+
+	p, e = auth.NewPriv("a/b/c", true, true, true, false)
+	assert.Nil(e)
+	assert.NotNil(p)
+	assert.Equal("a/b/c:c,r,u", p.String())
+	assert.True(p.Create("a/b/c"))
+	assert.True(p.Read("a/b/c"))
+	assert.True(p.Update("a/b/c"))
+	assert.False(p.Delete("a/b/c"))
+	assert.False(p.Write("a/b/c"))
+
+	p, e = auth.NewPriv("a/b/c", true, true, true, true)
+	assert.Nil(e)
+	assert.NotNil(p)
+	assert.Equal("a/b/c:c,r,u,d", p.String())
+	assert.True(p.Create("a/b/c"))
+	assert.True(p.Read("a/b/c"))
+	assert.True(p.Update("a/b/c"))
+	assert.True(p.Delete("a/b/c"))
+	assert.True(p.Write("a/b/c"))
+	assert.False(p.Create("e/f/g"))
+	assert.False(p.Read("e/f/g"))
+	assert.False(p.Update("e/f/g"))
+	assert.False(p.Delete("e/f/g"))
+	assert.False(p.Write("e/f/g"))
+}

--- a/auth/rsa.go
+++ b/auth/rsa.go
@@ -1,0 +1,167 @@
+package auth
+
+import (
+	"crypto"
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/sha256"
+	"crypto/x509"
+	"encoding/pem"
+	"errors"
+)
+
+var (
+	ErrIdentityEmpty   = errors.New("identity is empty")
+	ErrBadPEMFile      = errors.New("bad PEM file")
+	ErrUnknownPEMBlock = errors.New("unknown PEM block")
+)
+
+const RSAKeySize = 2048
+
+// RsaIdentity is just a small struct that clearly differentiates between the
+// private and public key of an RSA keypair.
+type RsaIdentity struct {
+	public  *rsa.PublicKey
+	private *rsa.PrivateKey
+}
+
+func Generate() (*RsaIdentity, error) {
+	priv, err := rsa.GenerateKey(rand.Reader, RSAKeySize)
+
+	return &RsaIdentity{
+		private: priv,
+		public:  &priv.PublicKey,
+	}, err
+}
+
+func Empty() *RsaIdentity {
+	return &RsaIdentity{
+		private: nil,
+		public:  nil,
+	}
+}
+
+func (r *RsaIdentity) MarshalText() ([]byte, error) {
+	if r.private != nil {
+		return pem.EncodeToMemory(&pem.Block{
+			Type:    "RSA PRIVATE KEY",
+			Headers: nil,
+			Bytes:   x509.MarshalPKCS1PrivateKey(r.private),
+		}), nil
+	} else if r.public != nil {
+		return pem.EncodeToMemory(&pem.Block{
+			Type:    "RSA PUBLIC KEY",
+			Headers: nil,
+			Bytes:   x509.MarshalPKCS1PublicKey(r.public),
+		}), nil
+	}
+
+	return nil, ErrIdentityEmpty
+}
+
+func (r *RsaIdentity) UnmarshalText(text []byte) error {
+	b, _ := pem.Decode(text)
+	if b == nil {
+		return ErrBadPEMFile
+	}
+
+	if b.Type == "RSA PRIVATE KEY" {
+		p, e := x509.ParsePKCS1PrivateKey(b.Bytes)
+		if e != nil {
+			return e
+		}
+
+		r.private = p
+		r.public = &p.PublicKey
+
+		return nil
+	} else if b.Type == "RSA PUBLIC KEY" {
+		p, e := x509.ParsePKCS1PublicKey(b.Bytes)
+		if e != nil {
+			return e
+		}
+
+		r.public = p
+
+		return nil
+	}
+
+	return ErrUnknownPEMBlock
+}
+
+// NewRsaIdentity returns a new identity with spefied keys.
+func NewRsaIdentity(pri *rsa.PrivateKey) *RsaIdentity {
+	return &RsaIdentity{
+		private: pri,
+		public:  &pri.PublicKey,
+	}
+}
+
+// RsaPubIdentity returns identity with public key. This identity object can
+// only be used to verify messages.
+func RsaPubIdentity(pub *rsa.PublicKey) *RsaIdentity {
+	return &RsaIdentity{
+		private: nil,
+		public:  pub,
+	}
+}
+
+func (r *RsaIdentity) PublicKey() *rsa.PublicKey {
+	return r.public
+}
+
+func (r *RsaIdentity) Public() *RsaIdentity {
+	return &RsaIdentity{
+		public:  r.public,
+		private: nil,
+	}
+}
+
+// Sign returns a signature made by combining the message and the signers private key
+// With the r.Verify function, the signature can be checked.
+func (r *RsaIdentity) Sign(msg []byte) ([]byte, error) {
+	hs := r.getHashSum(msg)
+
+	return rsa.SignPKCS1v15(rand.Reader, r.private, crypto.SHA256, hs)
+}
+
+// Verify checks if a message is signed by a given Public Key.
+func (r *RsaIdentity) Verify(msg []byte, sig []byte, pubKey *rsa.PublicKey) error {
+	hs := r.getHashSum(msg)
+
+	if pubKey == nil {
+		pubKey = r.PublicKey()
+	}
+
+	return rsa.VerifyPKCS1v15(pubKey, crypto.SHA256, hs, sig)
+}
+
+// Encrypt's the message using EncryptOAEP which encrypts the given message with RSA-OAEP.
+// https://en.wikipedia.org/wiki/Optimal_asymmetric_encryption_padding
+// Returns the encrypted message and an error.
+func (r *RsaIdentity) Encrypt(msg []byte, key *rsa.PublicKey) ([]byte, error) {
+	label := []byte("")
+	hash := sha256.New()
+
+	if key == nil {
+		key = r.PublicKey()
+	}
+
+	return rsa.EncryptOAEP(hash, rand.Reader, key, msg, label)
+}
+
+// Decrypt a message using your private key.
+// A received message should be encrypted using the receivers public key.
+func (r *RsaIdentity) Decrypt(msg []byte) ([]byte, error) {
+	label := []byte("")
+	hash := sha256.New()
+
+	return rsa.DecryptOAEP(hash, rand.Reader, r.private, msg, label)
+}
+
+func (r *RsaIdentity) getHashSum(msg []byte) []byte {
+	h := sha256.New()
+	h.Write(msg)
+
+	return h.Sum(nil)
+}

--- a/auth/rsa_test.go
+++ b/auth/rsa_test.go
@@ -1,0 +1,246 @@
+package auth_test
+
+import (
+	"bytes"
+	"crypto/rand"
+	"crypto/rsa"
+	"testing"
+
+	"github.com/project-safari/zebra/auth"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestNewRsaIdentity(t *testing.T) {
+	t.Parallel()
+
+	assert := assert.New(t)
+
+	henk, err := auth.Generate()
+	assert.Nil(err)
+
+	pkSize := henk.PublicKey().Size()
+	assert.Equal(256, pkSize)
+
+	b, e := henk.MarshalText()
+	assert.NotNil(b)
+	assert.Nil(e)
+	assert.Nil(henk.UnmarshalText(b))
+
+	x := auth.Empty()
+	b, e = x.MarshalText()
+	assert.Nil(b)
+	assert.NotNil(e)
+
+	e = x.UnmarshalText([]byte("blah"))
+	assert.NotNil(e)
+
+	henkPub := auth.RsaPubIdentity(henk.PublicKey())
+
+	b, e = henkPub.MarshalText()
+	assert.Nil(e)
+	assert.NotNil(b)
+	assert.Nil(x.UnmarshalText(b))
+}
+
+func TestEncrypt(t *testing.T) {
+	t.Parallel()
+
+	assert := assert.New(t)
+
+	priv, err := rsa.GenerateKey(rand.Reader, 2048)
+	assert.Nil(err)
+
+	henk := auth.NewRsaIdentity(priv)
+
+	priv, err = rsa.GenerateKey(rand.Reader, 2048)
+	assert.Nil(err)
+
+	jaap := auth.NewRsaIdentity(priv)
+
+	priv, err = rsa.GenerateKey(rand.Reader, 2048)
+	assert.Nil(err)
+
+	ingrid := auth.NewRsaIdentity(priv)
+
+	msg := []byte("Arme mensen kunnen niet met geld omgaan: ze geven alles uit aan eten en kleren, " +
+		"terwijl rijke mensen het heel verstandig op de bank zetten.")
+
+	// Lets encrypt it using Ingrid's public key.
+	henksMessage, err := henk.Encrypt(msg, ingrid.PublicKey())
+	assert.Nil(err)
+
+	jaapsMessage, err := jaap.Encrypt(msg, ingrid.PublicKey())
+	assert.Nil(err)
+
+	// Decrypt
+	hm, _ := ingrid.Decrypt(henksMessage)
+	jm, _ := ingrid.Decrypt(jaapsMessage)
+
+	// Compare the messages of Henk and Jaap, and the original
+	assert.True(bytes.Equal(hm, jm))
+	assert.True(bytes.Equal(hm, msg))
+}
+
+func TestEncryptionNeverTheSame(t *testing.T) {
+	t.Parallel()
+
+	assert := assert.New(t)
+
+	// Even when using the same public key, the encrypted messages are never the same
+	priv, err := rsa.GenerateKey(rand.Reader, 2048)
+	assert.Nil(err)
+
+	henk := auth.NewRsaIdentity(priv)
+
+	priv, err = rsa.GenerateKey(rand.Reader, 2048)
+	assert.Nil(err)
+
+	jaap := auth.NewRsaIdentity(priv)
+
+	priv, err = rsa.GenerateKey(rand.Reader, 2048)
+	assert.Nil(err)
+
+	joop := auth.NewRsaIdentity(priv)
+
+	priv, err = rsa.GenerateKey(rand.Reader, 2048)
+	assert.Nil(err)
+
+	koos := auth.NewRsaIdentity(priv)
+
+	priv, err = rsa.GenerateKey(rand.Reader, 2048)
+	assert.Nil(err)
+
+	kees := auth.NewRsaIdentity(priv)
+
+	priv, err = rsa.GenerateKey(rand.Reader, 2048)
+	assert.Nil(err)
+
+	erik := auth.NewRsaIdentity(priv)
+
+	// Added a couple of the same Identities at the end, just to prove that the
+	// encrypted outcome differs each time.
+	identities := []*auth.RsaIdentity{henk, jaap, joop, koos, kees, erik, erik, erik, erik}
+
+	priv, err = rsa.GenerateKey(rand.Reader, 2048)
+	assert.Nil(err)
+
+	ingrid := auth.NewRsaIdentity(priv)
+
+	msg := []byte("Aan ons land geen polonaise.")
+	msgs := make([][]byte, 0, len(identities))
+
+	for _, id := range identities {
+		// encrypt the message using Ingrid her public key
+		e, _ := id.Encrypt(msg, ingrid.PublicKey())
+		msgs = append(msgs, e)
+	}
+
+	s := []byte("start")
+	for _, m := range msgs {
+		assert.False(bytes.Equal(m, s))
+	}
+}
+
+func TestEncryptDecrypt(t *testing.T) {
+	t.Parallel()
+
+	assert := assert.New(t)
+
+	priv, err := rsa.GenerateKey(rand.Reader, 2048)
+	assert.Nil(err)
+
+	henk := auth.NewRsaIdentity(priv)
+
+	priv, err = rsa.GenerateKey(rand.Reader, 2048)
+	assert.Nil(err)
+
+	ingrid := auth.NewRsaIdentity(priv)
+
+	// a message from Henk to Ingrid
+	msg := []byte("Die uitkeringstrekkers pikken al onze banen in.")
+	// Lets encrypt it, we want to sent it to Ingrid, thus, we use her public key.
+	encryptedMessage, err := henk.Encrypt(msg, ingrid.PublicKey())
+	assert.Nil(err)
+
+	// Decrypt Message
+	plainTextMessage, err := ingrid.Decrypt(encryptedMessage)
+	assert.Nil(err)
+
+	assert.True(bytes.Equal(plainTextMessage, msg))
+}
+
+func TestEncryptDecryptMyself(t *testing.T) {
+	t.Parallel()
+
+	assert := assert.New(t)
+
+	// If anyone, even you, encrypts (id.e. “locks”) something with your public-key,
+	// only you can decrypt it (id.e. “unlock” it) with your secret, private key.
+	priv, err := rsa.GenerateKey(rand.Reader, 2048)
+	assert.Nil(err)
+
+	henk := auth.NewRsaIdentity(priv)
+
+	// a message from Henk
+	msg := []byte("Subsidized, dat is toch iets dat je krijgt als je eigenlijk niet goed genoeg bent?")
+
+	// Lets encrypt it, we want to sent it to self, thus, we need our public key.
+	encryptedMessage, err := henk.Encrypt(msg, nil)
+	assert.Nil(err)
+
+	// Decrypt Message
+	plainTextMessage, err := henk.Decrypt(encryptedMessage)
+	assert.Nil(err)
+
+	assert.True(bytes.Equal(plainTextMessage, msg))
+}
+
+func TestSignVerify(t *testing.T) {
+	t.Parallel()
+
+	assert := assert.New(t)
+
+	priv, err := rsa.GenerateKey(rand.Reader, 2048)
+	assert.Nil(err)
+
+	henk := auth.NewRsaIdentity(priv)
+
+	// A public message from Henk.
+	// note that the message is a byte array, not just a string.
+	msg := []byte("Wilders doet tenminste iets tegen de politiek.")
+
+	// Henk signs the message with his private key. This will show the recipient
+	// proof that this message is indeed from Henk
+	sig, _ := henk.Sign(msg)
+
+	// now, if the message msg is public, anyone can read it.
+	// the signature sig however, proves this message is from Henk.
+	priv, err = rsa.GenerateKey(rand.Reader, 2048)
+	assert.Nil(err)
+
+	ingrid := auth.NewRsaIdentity(priv)
+
+	priv, err = rsa.GenerateKey(rand.Reader, 2048)
+	assert.Nil(err)
+
+	hans := auth.NewRsaIdentity(priv)
+
+	err = ingrid.Verify(msg, sig, henk.PublicKey())
+	assert.Nil(err)
+
+	err = hans.Verify(msg, sig, henk.PublicKey())
+	assert.Nil(err)
+
+	// Let's see if we can break the signature verification
+	// (1) changing the message
+	err = hans.Verify([]byte("Wilders is een opruier"), sig, henk.PublicKey())
+	assert.NotNil(err)
+
+	// (2) changing the signature
+	err = hans.Verify(msg, []byte("I am not the signature"), henk.PublicKey())
+	assert.NotNil(err)
+
+	// (3) changing the public key
+	err = hans.Verify(msg, sig, ingrid.PublicKey())
+	assert.NotNil(err)
+}

--- a/auth/user.go
+++ b/auth/user.go
@@ -1,0 +1,59 @@
+package auth
+
+import (
+	"context"
+	"errors"
+
+	"github.com/project-safari/zebra"
+)
+
+var (
+	ErrKeyEmpty  = errors.New("key is empty")
+	ErrRoleEmpty = errors.New("role is empty")
+)
+
+type User struct {
+	zebra.NamedResource
+	Key  *RsaIdentity `json:"key"`
+	Role *Role        `json:"role"`
+}
+
+// Validate returns an error if the given Datacenter object has incorrect values.
+// Else, it returns nil.
+func (u *User) Validate(ctx context.Context) error {
+	if u.Key == nil {
+		return ErrKeyEmpty
+	}
+
+	if u.Role == nil {
+		return ErrRoleEmpty
+	}
+
+	return u.NamedResource.Validate(ctx)
+}
+
+const SharedSecret = "खुल जा सिम सिम" //nolint:gosec
+
+func (u *User) Authenticate(token string) error {
+	return u.Key.Verify([]byte(SharedSecret), []byte(token), nil)
+}
+
+func (u *User) Create(resource string) bool {
+	return u.Role.Create(resource)
+}
+
+func (u *User) Read(resource string) bool {
+	return u.Role.Read(resource)
+}
+
+func (u *User) Write(resource string) bool {
+	return u.Role.Write(resource)
+}
+
+func (u *User) Delete(resource string) bool {
+	return u.Role.Delete(resource)
+}
+
+func (u *User) Update(resource string) bool {
+	return u.Role.Update(resource)
+}

--- a/auth/user_test.go
+++ b/auth/user_test.go
@@ -1,0 +1,114 @@
+package auth_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/project-safari/zebra/auth"
+	"github.com/stretchr/testify/assert"
+)
+
+const userType = "user"
+
+//nolint:funlen
+func TestUser(t *testing.T) {
+	t.Parallel()
+
+	assert := assert.New(t)
+	all, e := auth.NewPriv("", true, true, true, true)
+	assert.Nil(e)
+	assert.NotNil(all)
+	admin := &auth.Role{"admin", []*auth.Priv{all}}
+
+	writeAll, e := auth.NewPriv("", true, false, true, true)
+	assert.Nil(e)
+	assert.NotNil(writeAll)
+	writer := &auth.Role{"writer", []*auth.Priv{writeAll}}
+
+	readAll, e := auth.NewPriv("", false, true, false, false)
+	assert.Nil(e)
+	assert.NotNil(all)
+
+	rwOne, e := auth.NewPriv("eden", true, true, true, true)
+	assert.Nil(e)
+	assert.NotNil(rwOne)
+
+	user := &auth.Role{"user", []*auth.Priv{readAll, rwOne}}
+
+	godKey, err := auth.Generate()
+	assert.Nil(err)
+	assert.NotNil(godKey)
+
+	ctx := context.Background()
+
+	god := new(auth.User)
+
+	assert.NotNil(god.Validate(ctx))
+
+	god.Name = "almighty"
+	god.ID = "00000000000001"
+	god.Type = userType
+	assert.NotNil(god.Validate(ctx))
+
+	god.Key = godKey
+	assert.NotNil(god.Validate(ctx))
+
+	god.Role = admin
+	assert.Nil(god.Validate(ctx))
+
+	luciferKey, err := auth.Generate()
+	assert.Nil(err)
+	assert.NotNil(luciferKey)
+
+	lucifer := new(auth.User)
+	lucifer.Name = "lucifer"
+	lucifer.ID = "00000000000002"
+	lucifer.Type = userType
+	lucifer.Key = luciferKey
+	lucifer.Role = writer
+
+	adamKey, err := auth.Generate()
+	assert.Nil(err)
+	assert.NotNil(adamKey)
+
+	adam := new(auth.User)
+	adam.Name = "adam"
+	adam.ID = "00000000000003"
+	adam.Type = userType
+	adam.Key = adamKey
+	adam.Role = user
+
+	eveKey, err := auth.Generate()
+	assert.Nil(err)
+	assert.NotNil(eveKey)
+
+	eve := new(auth.User)
+	eve.Name = "eve"
+	eve.ID = "00000000000004"
+	eve.Type = userType
+	eve.Key = eveKey
+	eve.Role = user
+
+	token, err := godKey.Sign([]byte(auth.SharedSecret))
+	assert.Nil(err)
+	assert.NotEmpty(token)
+
+	assert.Nil(god.Authenticate(string(token)))
+	assert.NotNil(lucifer.Authenticate(string(token)))
+
+	assert.True(god.Create("universe"))
+	assert.True(god.Read("universe"))
+	assert.True(god.Delete("universe"))
+	assert.True(god.Update("universe"))
+	assert.True(god.Write("universe"))
+	assert.False(lucifer.Read("universe"))
+	assert.True(lucifer.Write("universe"))
+	assert.False(adam.Write("something"))
+	assert.False(adam.Delete("something"))
+	assert.False(eve.Create("universe"))
+	assert.False(eve.Delete("universe"))
+	assert.True(adam.Create("eden"))
+	assert.True(eve.Write("eden"))
+	assert.True(eve.Update("eden"))
+	assert.False(eve.Update("universe"))
+}


### PR DESCRIPTION
Models user as a NamedResource with and ssh/rsa public key and a
specific role.

A role is defined as a set of privileges and a privelege captures the
create, read, update and deleted operations against a resource key. If
the resource key is empty then the privilege applies to all resources.

Signed-off-by: Ravi Chamarthy <ravi@chamarthy.dev>