### PR TITLE
api for type meta

### DIFF
--- a/api/api_test.go
+++ b/api/api_test.go
@@ -41,7 +41,7 @@ func TestInitialize(t *testing.T) {
 	t.Parallel()
 	assert := assert.New(t)
 
-	f := zebra.Factory().Add("VLANPool", func() zebra.Resource { return new(network.VLANPool) })
+	f := zebra.Factory().Add(network.VLANPoolType())
 
 	api := api.NewResourceAPI(f)
 	assert.Nil(api.Initialize("teststore"))
@@ -49,8 +49,9 @@ func TestInitialize(t *testing.T) {
 
 func TestGetResources(t *testing.T) {
 	t.Parallel()
+
 	assert := assert.New(t)
-	f := zebra.Factory().Add("VLANPool", func() zebra.Resource { return new(network.VLANPool) })
+	f := zebra.Factory().Add(network.VLANPoolType())
 	myAPI := api.NewResourceAPI(f)
 	assert.Nil(myAPI.Initialize("teststore"))
 
@@ -69,7 +70,7 @@ func TestGetResourcesByID(t *testing.T) {
 	t.Parallel()
 	assert := assert.New(t)
 
-	f := zebra.Factory().Add("VLANPool", func() zebra.Resource { return new(network.VLANPool) })
+	f := zebra.Factory().Add(network.VLANPoolType())
 	myAPI := api.NewResourceAPI(f)
 	assert.Nil(myAPI.Initialize("teststore"))
 
@@ -107,7 +108,7 @@ func TestGetResourcesByType(t *testing.T) {
 	t.Parallel()
 	assert := assert.New(t)
 
-	f := zebra.Factory().Add("VLANPool", func() zebra.Resource { return new(network.VLANPool) })
+	f := zebra.Factory().Add(network.VLANPoolType())
 	myAPI := api.NewResourceAPI(f)
 	assert.Nil(myAPI.Initialize("teststore"))
 
@@ -136,7 +137,7 @@ func TestGetResourcesByProperty(t *testing.T) { //nolint:funlen
 	t.Parallel()
 	assert := assert.New(t)
 
-	f := zebra.Factory().Add("VLANPool", func() zebra.Resource { return new(network.VLANPool) })
+	f := zebra.Factory().Add(network.VLANPoolType())
 	myAPI := api.NewResourceAPI(f)
 	assert.Nil(myAPI.Initialize("teststore"))
 
@@ -199,7 +200,7 @@ func TestGetResourcesByLabel(t *testing.T) {
 	t.Parallel()
 	assert := assert.New(t)
 
-	f := zebra.Factory().Add("VLANPool", func() zebra.Resource { return new(network.VLANPool) })
+	f := zebra.Factory().Add(network.VLANPoolType())
 	myAPI := api.NewResourceAPI(f)
 	assert.Nil(myAPI.Initialize("teststore"))
 
@@ -259,8 +260,7 @@ func TestPutResource(t *testing.T) { //nolint:funlen
 
 	t.Cleanup(func() { os.Remove("teststore/resources/01/00000003") })
 
-	f := zebra.Factory().Add("VLANPool", func() zebra.Resource { return new(network.VLANPool) })
-	f.Add("Lab", func() zebra.Resource { return new(dc.Lab) })
+	f := zebra.Factory().Add(network.VLANPoolType()).Add(dc.LabType())
 	myAPI := api.NewResourceAPI(f)
 	assert.Nil(myAPI.Initialize("teststore"))
 
@@ -331,7 +331,7 @@ func TestDeleteResource(t *testing.T) { //nolint:funlen
 
 	t.Cleanup(func() { os.RemoveAll(root) })
 
-	f := zebra.Factory().Add("Lab", func() zebra.Resource { return new(network.VLANPool) })
+	f := zebra.Factory().Add(dc.LabType())
 	myAPI := api.NewResourceAPI(f)
 	assert.Nil(myAPI.Initialize(root))
 

--- a/auth/user.go
+++ b/auth/user.go
@@ -15,6 +15,14 @@ var (
 	ErrRoleEmpty     = errors.New("role is empty")
 )
 
+func UserType() zebra.Type {
+	return zebra.Type{
+		Name:        "User",
+		Description: "zebra user",
+		Constructor: func() zebra.Resource { return new(User) },
+	}
+}
+
 type User struct {
 	zebra.NamedResource
 	Key          *RsaIdentity `json:"key"`

--- a/auth/user_test.go
+++ b/auth/user_test.go
@@ -41,9 +41,9 @@ func TestUser(t *testing.T) {
 
 	ctx := context.Background()
 
-	god := new(auth.User)
-
-	assert.NotNil(god.Validate(ctx))
+	uType := auth.UserType()
+	god, ok := uType.New().(*auth.User)
+	assert.True(ok)
 
 	god.Name = "almighty"
 	god.ID = "00000000000001"
@@ -116,6 +116,10 @@ func TestUser(t *testing.T) {
 	assert.False(eve.Create("universe"))
 	assert.False(eve.Delete("universe"))
 	assert.True(adam.Create("eden"))
+	assert.True(eve.Write("eden"))
+	assert.True(eve.Update("eden"))
+	assert.False(eve.Update("universe"))
+
 	assert.True(eve.Write("eden"))
 	assert.True(eve.Update("eden"))
 	assert.False(eve.Update("universe"))

--- a/cmd/server/labels.go
+++ b/cmd/server/labels.go
@@ -1,0 +1,92 @@
+package main
+
+import (
+	"context"
+	"net/http"
+
+	"github.com/julienschmidt/httprouter"
+	"github.com/project-safari/zebra"
+)
+
+func handleLabels(ctx context.Context, store zebra.Store) httprouter.Handle {
+	return func(res http.ResponseWriter, req *http.Request, params httprouter.Params) {
+		labelReq := &struct {
+			Labels []string `json:"labels"`
+		}{Labels: []string{}}
+
+		if err := readReq(ctx, req, labelReq); err != nil {
+			res.WriteHeader(http.StatusBadRequest)
+
+			return
+		}
+
+		matchSet := makeMatchSet(labelReq.Labels)
+
+		labelRes := &struct {
+			Labels map[string][]string `json:"labels"`
+		}{}
+
+		// Iterate over all resources and cache the labels.
+		// We may have to optimize this query by adding a special
+		// store that will keep this cache intact as labels are
+		// added and removed to the resources. For now it a naive
+		// o(n)*o(m) implementation, where n is number of resources
+		// and m is amortized number of labels per resource
+		rMap := store.Query()
+		labelRes.Labels = matchLabels(matchSet, rMap)
+
+		writeJSON(ctx, res, labelRes)
+	}
+}
+
+func makeMatchSet(labels []string) map[string]struct{} {
+	matchSet := make(map[string]struct{}, len(labels))
+	for _, l := range labels {
+		matchSet[l] = struct{}{}
+	}
+
+	return matchSet
+}
+
+func matchLabels(matchSet map[string]struct{}, rMap *zebra.ResourceMap) map[string][]string {
+	matchAny := len(matchSet) == 0
+	labelSet := make(map[string]map[string]struct{})
+
+	for _, resList := range rMap.Resources {
+		for _, r := range resList.Resources {
+			labels := r.GetLabels()
+			for k, v := range labels {
+				_, matchOk := matchSet[k] // check if key is list
+				matched := matchAny || matchOk
+
+				if matched {
+					valueSet, ok := labelSet[k]
+					if !ok {
+						valueSet = make(map[string]struct{})
+						labelSet[k] = valueSet
+					}
+
+					// add the value
+					valueSet[v] = struct{}{}
+				}
+			}
+		}
+	}
+
+	return makeLabelValues(labelSet)
+}
+
+func makeLabelValues(labelSet map[string]map[string]struct{}) map[string][]string {
+	labelVals := make(map[string][]string)
+
+	for k, valueSet := range labelSet {
+		valueList := make([]string, 0, len(valueSet))
+		for v := range valueSet {
+			valueList = append(valueList, v)
+		}
+
+		labelVals[k] = valueList
+	}
+
+	return labelVals
+}

--- a/cmd/server/labels_test.go
+++ b/cmd/server/labels_test.go
@@ -1,0 +1,124 @@
+package main //nolint:testpackage
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"testing"
+
+	"github.com/project-safari/zebra"
+	"github.com/project-safari/zebra/dc"
+	"github.com/project-safari/zebra/store"
+	"github.com/stretchr/testify/assert"
+)
+
+func makeLabelRequest(assert *assert.Assertions, labels ...string) *http.Request {
+	req, err := http.NewRequest("GET", "/api/v1/labels", nil)
+	assert.Nil(err)
+	assert.NotNil(req)
+
+	v := map[string][]string{"labels": labels}
+	b, e := json.Marshal(v)
+	assert.Nil(e)
+
+	req.Body = ioutil.NopCloser(bytes.NewBuffer(b))
+
+	return req
+}
+
+func TestBadLabelReq(t *testing.T) {
+	t.Parallel()
+	assert := assert.New(t)
+
+	h := handleLabels(context.Background(), nil)
+	rr := httptest.NewRecorder()
+	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		h(w, r, nil)
+	})
+
+	req, err := http.NewRequest("GET", "/api/v1/labels", nil)
+	assert.Nil(err)
+	assert.NotNil(req)
+
+	v := "{....}" // bad json
+	req.Body = ioutil.NopCloser(bytes.NewBufferString(v))
+
+	handler.ServeHTTP(rr, req)
+	assert.Equal(rr.Code, http.StatusBadRequest)
+}
+
+func TestAllLabels(t *testing.T) {
+	t.Parallel()
+	assert := assert.New(t)
+
+	store := makeStore(assert, "test_all_labels")
+	assert.NotNil(store)
+
+	defer func() {
+		assert.Nil(os.RemoveAll("./test_all_labels"))
+	}()
+
+	h := handleLabels(context.Background(), store)
+	rr := httptest.NewRecorder()
+	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		h(w, r, nil)
+	})
+
+	req := makeLabelRequest(assert)
+	handler.ServeHTTP(rr, req)
+
+	assert.Equal(rr.Code, http.StatusOK)
+}
+
+func TestLabels(t *testing.T) {
+	t.Parallel()
+	assert := assert.New(t)
+
+	store := makeStore(assert, "test_labels")
+	assert.NotNil(store)
+
+	defer func() {
+		assert.Nil(os.RemoveAll("./test_labels"))
+	}()
+
+	h := handleLabels(context.Background(), store)
+	rr := httptest.NewRecorder()
+	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		h(w, r, nil)
+	})
+
+	req := makeLabelRequest(assert, "label5", "label7")
+	handler.ServeHTTP(rr, req)
+
+	assert.Equal(rr.Code, http.StatusOK)
+}
+
+func makeStore(assert *assert.Assertions, root string) zebra.Store {
+	s := store.NewResourceStore(root, store.DefaultFactory())
+	assert.Nil(s.Initialize())
+
+	labels := zebra.Labels{}
+
+	for i := 0; i < 10; i++ {
+		key := fmt.Sprintf("label%d", i)
+		value := fmt.Sprintf("value%d", i)
+		labels[key] = value
+	}
+
+	// create 100 labs
+	for i := 0; i < 100; i++ {
+		l := new(dc.Lab)
+		l.Name = fmt.Sprintf("lab-%d", i+1)
+		l.Type = "Lab"
+		l.BaseResource = *zebra.NewBaseResource("Lab", labels)
+
+		assert.Nil(s.Create(l))
+	}
+
+	return s
+}

--- a/cmd/server/login_test.go
+++ b/cmd/server/login_test.go
@@ -61,7 +61,7 @@ func makeUser(assert *assert.Assertions) *auth.User {
 }
 
 func makeQueryStore(root string, assert *assert.Assertions, user *auth.User) zebra.Store {
-	factory := initTypes()
+	factory := store.AllTypes()
 	assert.NotNil(factory)
 
 	store := store.NewResourceStore(root, factory)

--- a/cmd/server/login_test.go
+++ b/cmd/server/login_test.go
@@ -61,7 +61,7 @@ func makeUser(assert *assert.Assertions) *auth.User {
 }
 
 func makeQueryStore(root string, assert *assert.Assertions, user *auth.User) zebra.Store {
-	factory := store.AllTypes()
+	factory := store.DefaultFactory()
 	assert.NotNil(factory)
 
 	store := store.NewResourceStore(root, factory)

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -115,6 +115,7 @@ func httpHandler(ctx context.Context, cfgStore *config.Store) http.Handler {
 	router := httprouter.New()
 	router.GET("/api/v1/resources", handleQuery(resAPI))
 	router.GET("/api/v1/types", handleTypes(ctx))
+	router.GET("/api/v1/labels", handleLabels(ctx, resAPI.Store))
 	router.GET("/login", handleLogin(ctx, resAPI.Store, authKey))
 
 	return router
@@ -153,6 +154,7 @@ func writeJSON(ctx context.Context, res http.ResponseWriter, data interface{}) {
 
 	res.Header().Set("Content-Type", "application/json")
 	res.WriteHeader(http.StatusOK)
+
 	if _, err := res.Write(bytes); err != nil {
 		log.Error(err, "error writing response")
 	}

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -12,12 +12,8 @@ import (
 	"github.com/go-logr/logr"
 	"github.com/go-logr/zerologr"
 	"github.com/julienschmidt/httprouter"
-	"github.com/project-safari/zebra"
 	"github.com/project-safari/zebra/api"
-	"github.com/project-safari/zebra/auth"
-	"github.com/project-safari/zebra/compute"
-	"github.com/project-safari/zebra/dc"
-	"github.com/project-safari/zebra/network"
+	"github.com/project-safari/zebra/store"
 	"github.com/rs/zerolog"
 	"github.com/spf13/cobra"
 	"gojini.dev/config"
@@ -107,7 +103,7 @@ func httpHandler(ctx context.Context, cfgStore *config.Store) http.Handler {
 		panic(e)
 	}
 
-	factory := initTypes()
+	factory := store.AllTypes()
 
 	resAPI := api.NewResourceAPI(factory)
 	if e := resAPI.Initialize(storeCfg.Root); e != nil {
@@ -120,66 +116,6 @@ func httpHandler(ctx context.Context, cfgStore *config.Store) http.Handler {
 	router.GET("/login", handleLogin(ctx, resAPI.Store, authKey))
 
 	return router
-}
-
-func initTypes() zebra.ResourceFactory {
-	factory := zebra.Factory()
-
-	// network resources
-	factory.Add("Switch", func() zebra.Resource {
-		return new(network.Switch)
-	})
-	factory.Add("IPAddressPool", func() zebra.Resource {
-		return new(network.IPAddressPool)
-	})
-	factory.Add("VLANPool", func() zebra.Resource {
-		return new(network.VLANPool)
-	})
-
-	// dc resources
-	factory.Add("Datacenter", func() zebra.Resource {
-		return new(dc.Datacenter)
-	})
-	factory.Add("Lab", func() zebra.Resource {
-		return new(dc.Lab)
-	})
-	factory.Add("Rack", func() zebra.Resource {
-		return new(dc.Rack)
-	})
-
-	// compute resources
-	factory.Add("Server", func() zebra.Resource {
-		return new(compute.Server)
-	})
-	factory.Add("ESX", func() zebra.Resource {
-		return new(compute.ESX)
-	})
-	factory.Add("VCenter", func() zebra.Resource {
-		return new(compute.VCenter)
-	})
-	factory.Add("VM", func() zebra.Resource {
-		return new(compute.VM)
-	})
-
-	// other resources
-	factory.Add("BaseResource", func() zebra.Resource {
-		return new(zebra.BaseResource)
-	})
-
-	factory.Add("NamedResource", func() zebra.Resource {
-		return new(zebra.NamedResource)
-	})
-
-	factory.Add("Credentials", func() zebra.Resource {
-		return new(zebra.Credentials)
-	})
-
-	factory.Add("User", func() zebra.Resource {
-		return new(auth.User)
-	})
-
-	// Need to add all the known types here
-	return factory
 }
 
 func handleQuery(resAPI *api.ResourceAPI) httprouter.Handle {

--- a/cmd/server/types.go
+++ b/cmd/server/types.go
@@ -1,0 +1,63 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"io/ioutil"
+	"net/http"
+
+	"github.com/go-logr/logr"
+	"github.com/julienschmidt/httprouter"
+	"github.com/project-safari/zebra"
+	"github.com/project-safari/zebra/store"
+)
+
+func handleTypes(ctx context.Context) httprouter.Handle {
+	allTypes := store.DefaultFactory()
+
+	return func(res http.ResponseWriter, req *http.Request, params httprouter.Params) {
+		typeReq := &struct {
+			Types []string `json:"types"`
+		}{Types: []string{}}
+
+		if err := readReq(ctx, req, typeReq); err != nil {
+			res.WriteHeader(http.StatusBadRequest)
+
+			return
+		}
+
+		typeRes := &struct {
+			Types []zebra.Type `json:"types"`
+		}{Types: []zebra.Type{}}
+
+		if len(typeReq.Types) == 0 {
+			// return all types
+			typeRes.Types = allTypes.Types()
+		} else {
+			for _, t := range typeReq.Types {
+				if aType, ok := allTypes.Type(t); ok {
+					typeRes.Types = append(typeRes.Types, aType)
+				}
+			}
+		}
+
+		writeJSON(ctx, res, typeRes)
+	}
+}
+
+func readReq(ctx context.Context, req *http.Request, data interface{}) error {
+	log := logr.FromContextOrDiscard(ctx)
+
+	body, err := ioutil.ReadAll(req.Body)
+	if err != nil {
+		return nil
+	}
+
+	log.Info("request", "body", string(body))
+
+	if len(body) > 0 {
+		err = json.Unmarshal(body, data)
+	}
+
+	return err
+}

--- a/cmd/server/types_test.go
+++ b/cmd/server/types_test.go
@@ -1,0 +1,80 @@
+package main //nolint:testpackage
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"io/ioutil"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func makeTypeRequest(assert *assert.Assertions, types ...string) *http.Request {
+	req, err := http.NewRequest("GET", "/api/v1/types", nil)
+	assert.Nil(err)
+	assert.NotNil(req)
+
+	v := map[string][]string{"types": types}
+	b, e := json.Marshal(v)
+	assert.Nil(e)
+
+	req.Body = ioutil.NopCloser(bytes.NewBuffer(b))
+
+	return req
+}
+
+func TestBadReq(t *testing.T) {
+	t.Parallel()
+	assert := assert.New(t)
+
+	h := handleTypes(context.Background())
+	rr := httptest.NewRecorder()
+	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		h(w, r, nil)
+	})
+
+	req, err := http.NewRequest("GET", "/api/v1/types", nil)
+	assert.Nil(err)
+	assert.NotNil(req)
+
+	v := "{....}" // bad json
+	req.Body = ioutil.NopCloser(bytes.NewBufferString(v))
+
+	handler.ServeHTTP(rr, req)
+	assert.Equal(rr.Code, http.StatusBadRequest)
+}
+
+func TestDefaultFactory(t *testing.T) {
+	t.Parallel()
+	assert := assert.New(t)
+
+	h := handleTypes(context.Background())
+	rr := httptest.NewRecorder()
+	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		h(w, r, nil)
+	})
+
+	req := makeTypeRequest(assert)
+	handler.ServeHTTP(rr, req)
+
+	assert.Equal(rr.Code, http.StatusOK)
+}
+
+func TestTypes(t *testing.T) {
+	t.Parallel()
+	assert := assert.New(t)
+
+	h := handleTypes(context.Background())
+	rr := httptest.NewRecorder()
+	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		h(w, r, nil)
+	})
+
+	req := makeTypeRequest(assert, "Server", "Switch")
+	handler.ServeHTTP(rr, req)
+
+	assert.Equal(rr.Code, http.StatusOK)
+}

--- a/compute/compute.go
+++ b/compute/compute.go
@@ -21,6 +21,14 @@ var ErrVCenterEmpty = errors.New("VCenter id is empty")
 
 var ErrServerIDEmtpy = errors.New("server id is empty")
 
+func ServerType() zebra.Type {
+	return zebra.Type{
+		Name:        "Server",
+		Description: "compute server",
+		Constructor: func() zebra.Resource { return new(Server) },
+	}
+}
+
 // A Server represents a server with credentials, a serial number, board IP, and
 // model information.
 type Server struct {
@@ -48,6 +56,14 @@ func (s *Server) Validate(ctx context.Context) error {
 	return s.NamedResource.Validate(ctx)
 }
 
+func ESXType() zebra.Type {
+	return zebra.Type{
+		Name:        "ESX",
+		Description: "VMWare ESX server",
+		Constructor: func() zebra.Resource { return new(ESX) },
+	}
+}
+
 // An ESX represents an ESX server with credentials, an associated server, and IP.
 type ESX struct {
 	zebra.NamedResource
@@ -72,6 +88,14 @@ func (e *ESX) Validate(ctx context.Context) error {
 	return e.NamedResource.Validate(ctx)
 }
 
+func VCenterType() zebra.Type {
+	return zebra.Type{
+		Name:        "VCenter",
+		Description: "VMWare vcenter",
+		Constructor: func() zebra.Resource { return new(VCenter) },
+	}
+}
+
 // A VCenter has credentials and an IP.
 type VCenter struct {
 	zebra.NamedResource
@@ -89,6 +113,14 @@ func (v *VCenter) Validate(ctx context.Context) error {
 	}
 
 	return v.NamedResource.Validate(ctx)
+}
+
+func VMType() zebra.Type {
+	return zebra.Type{
+		Name:        "VM",
+		Description: "virtual machine",
+		Constructor: func() zebra.Resource { return new(VM) },
+	}
 }
 
 // A VM is represented by a set of credentials, associated ESX ID, management IP,

--- a/compute/compute_test.go
+++ b/compute/compute_test.go
@@ -19,7 +19,12 @@ func TestServer(t *testing.T) {
 
 	ctx := context.Background()
 
-	server := new(compute.Server)
+	serverType := compute.ServerType()
+	assert.NotNil(serverType)
+
+	server, ok := serverType.New().(*compute.Server)
+	assert.True(ok)
+	assert.NotNil(server)
 	assert.NotNil(server.Validate(ctx))
 
 	server.ID = "hello"
@@ -53,7 +58,9 @@ func TestESX(t *testing.T) {
 
 	ctx := context.Background()
 
-	esx := new(compute.ESX)
+	esxType := compute.ESXType()
+	esx, ok := esxType.New().(*compute.ESX)
+	assert.True(ok)
 	assert.NotNil(esx.Validate(ctx))
 
 	esx.ID = "rolling in the deep"
@@ -84,7 +91,9 @@ func TestVCenter(t *testing.T) {
 
 	ctx := context.Background()
 
-	vcenter := new(compute.VCenter)
+	vcType := compute.VCenterType()
+	vcenter, ok := vcType.New().(*compute.VCenter)
+	assert.True(ok)
 	assert.NotNil(vcenter.Validate(ctx))
 
 	vcenter.ID = "blah"
@@ -112,7 +121,9 @@ func TestVM(t *testing.T) {
 
 	ctx := context.Background()
 
-	machine := new(compute.VM)
+	vmType := compute.VMType()
+	machine, ok := vmType.New().(*compute.VM)
+	assert.True(ok)
 	assert.NotNil(machine.Validate(ctx))
 
 	machine.ID = "can you hear me"

--- a/dc/dc.go
+++ b/dc/dc.go
@@ -12,6 +12,14 @@ var ErrAddressEmpty = errors.New("address is empty")
 
 var ErrRowEmpty = errors.New("row is empty")
 
+func DataCenterType() zebra.Type {
+	return zebra.Type{
+		Name:        "Datacenter",
+		Description: "data center",
+		Constructor: func() zebra.Resource { return new(Datacenter) },
+	}
+}
+
 // A Datacenter represents the physical building. It is a named resource also
 // with a building address.
 type Datacenter struct {
@@ -29,9 +37,25 @@ func (dc *Datacenter) Validate(ctx context.Context) error {
 	return dc.NamedResource.Validate(ctx)
 }
 
+func LabType() zebra.Type {
+	return zebra.Type{
+		Name:        "Lab",
+		Description: "data center lab",
+		Constructor: func() zebra.Resource { return new(Lab) },
+	}
+}
+
 // A Lab represents the lab consisting of a name and an ID.
 type Lab struct {
 	zebra.NamedResource
+}
+
+func RackType() zebra.Type {
+	return zebra.Type{
+		Name:        "Rack",
+		Description: "server rack",
+		Constructor: func() zebra.Resource { return new(Rack) },
+	}
 }
 
 // A Rack represents a datacenter rack. It consists of a name, ID, and associated

--- a/dc/dc_test.go
+++ b/dc/dc_test.go
@@ -17,7 +17,11 @@ func TestDatacenter(t *testing.T) {
 	assert := assert.New(t)
 
 	ctx := context.Background()
-	datacenter := new(dc.Datacenter)
+	dcType := dc.DataCenterType()
+	assert.NotNil(dcType)
+
+	datacenter, ok := dcType.New().(*dc.Datacenter)
+	assert.True(ok)
 	assert.NotNil(datacenter.Validate(ctx))
 
 	datacenter.ID = "abracadabra"
@@ -25,6 +29,9 @@ func TestDatacenter(t *testing.T) {
 	datacenter.Name = "jasmine"
 	datacenter.Address = "1 palace st, agrabah"
 	assert.Nil(datacenter.Validate(ctx))
+
+	labType := dc.LabType()
+	assert.NotNil(labType)
 }
 
 // TestRack tests the *Rack Validate function with a pass and a fail case.
@@ -33,7 +40,9 @@ func TestRack(t *testing.T) {
 	assert := assert.New(t)
 
 	ctx := context.Background()
-	rack := new(dc.Rack)
+	rackType := dc.RackType()
+	rack, ok := rackType.New().(*dc.Rack)
+	assert.True(ok)
 	assert.NotNil(rack.Validate(ctx))
 
 	rack.ID = "abracadabra"

--- a/filestore/filestore_test.go
+++ b/filestore/filestore_test.go
@@ -11,7 +11,7 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-const vlan string = "VLANPool"
+const vlan = "VLANPool"
 
 func TestInitialize(t *testing.T) {
 	t.Parallel()
@@ -36,7 +36,7 @@ func TestCreate(t *testing.T) {
 	resource.Labels = zebra.Labels{"key": "value"}
 
 	types := zebra.Factory()
-	types.Add(vlan, func() zebra.Resource { return new(network.VLANPool) })
+	types.Add(network.VLANPoolType())
 
 	fs := filestore.NewFileStore(root, types)
 
@@ -67,7 +67,7 @@ func TestLoad(t *testing.T) {
 	resource := getVLAN()
 
 	types := zebra.Factory()
-	types.Add(vlan, func() zebra.Resource { return new(network.VLANPool) })
+	types.Add(network.VLANPoolType())
 
 	fs := filestore.NewFileStore(root, types)
 
@@ -102,7 +102,7 @@ func TestDelete(t *testing.T) {
 	resource := getVLAN()
 
 	types := zebra.Factory()
-	types.Add(vlan, func() zebra.Resource { return new(network.VLANPool) })
+	types.Add(network.VLANPoolType())
 
 	fs := filestore.NewFileStore(root, types)
 
@@ -138,7 +138,7 @@ func TestClearStore(t *testing.T) {
 	resource2 := getVLAN()
 
 	types := zebra.Factory()
-	types.Add(vlan, func() zebra.Resource { return new(network.VLANPool) })
+	types.Add(network.VLANPoolType())
 
 	fs := filestore.NewFileStore(root, types)
 
@@ -219,8 +219,8 @@ func TestBadLoad2(t *testing.T) {
 	t.Cleanup(func() { os.RemoveAll(root) })
 
 	types := zebra.Factory()
-	types.Add(vlan, func() zebra.Resource { return new(network.VLANPool) })
-	types.Add("Switch", func() zebra.Resource { return new(network.Switch) })
+	types.Add(network.VLANPoolType())
+	types.Add(network.SwitchType())
 
 	fs := filestore.NewFileStore(root, types)
 

--- a/network/network.go
+++ b/network/network.go
@@ -21,6 +21,14 @@ var ErrMaskEmpty = errors.New("mask is nil")
 
 var ErrInvalidRange = errors.New("range bounds are invalid, start is greater than end")
 
+func SwitchType() zebra.Type {
+	return zebra.Type{
+		Name:        "Switch",
+		Description: "network server",
+		Constructor: func() zebra.Resource { return new(Switch) },
+	}
+}
+
 // A Switch represents a switching device which has an ID, an associated IP
 // address, a serial number, model, and ports.
 type Switch struct {
@@ -53,6 +61,14 @@ func (s *Switch) Validate(ctx context.Context) error {
 	return s.BaseResource.Validate(ctx)
 }
 
+func IPAddressPoolType() zebra.Type {
+	return zebra.Type{
+		Name:        "IPAddressPool",
+		Description: "ip address pool",
+		Constructor: func() zebra.Resource { return new(IPAddressPool) },
+	}
+}
+
 // An IPAddressPool represents a range of consecutive IP addresses belonging
 // to the same network.
 type IPAddressPool struct {
@@ -72,6 +88,14 @@ func (p *IPAddressPool) Validate(ctx context.Context) error {
 	}
 
 	return p.BaseResource.Validate(ctx)
+}
+
+func VLANPoolType() zebra.Type {
+	return zebra.Type{
+		Name:        "VLANPool",
+		Description: "vlan pool",
+		Constructor: func() zebra.Resource { return new(VLANPool) },
+	}
 }
 
 // A VLANPool represents a pool of VLANs belonging to the same network.

--- a/network/network_test.go
+++ b/network/network_test.go
@@ -18,7 +18,9 @@ func TestSwitch(t *testing.T) {
 	assert := assert.New(t)
 
 	ctx := context.Background()
-	switch1 := new(network.Switch)
+	switchType := network.SwitchType()
+	switch1, ok := switchType.New().(*network.Switch)
+	assert.True(ok)
 	assert.NotNil(switch1.Validate(ctx))
 
 	switch1.ID = "aaaa"
@@ -62,7 +64,9 @@ func TestIPAddressPool(t *testing.T) {
 	assert := assert.New(t)
 
 	ctx := context.Background()
-	pool := new(network.IPAddressPool)
+	ipPoolType := network.IPAddressPoolType()
+	pool, ok := ipPoolType.New().(*network.IPAddressPool)
+	assert.True(ok)
 	assert.NotNil(pool.Validate(ctx))
 
 	pool.ID = "aaaa"
@@ -93,7 +97,9 @@ func TestVLANPool(t *testing.T) {
 	assert := assert.New(t)
 
 	ctx := context.Background()
-	pool := new(network.VLANPool)
+	vlanPoolType := network.VLANPoolType()
+	pool, ok := vlanPoolType.New().(*network.VLANPool)
+	assert.True(ok)
 	assert.NotNil(pool.Validate(ctx))
 
 	pool.ID = "cccc"

--- a/resmap_test.go
+++ b/resmap_test.go
@@ -15,7 +15,7 @@ func TestAddNew(t *testing.T) {
 	f := zebra.Factory()
 	assert.NotNil(f)
 
-	f.Add("Switch", func() zebra.Resource { return new(network.Switch) })
+	f.Add(network.SwitchType())
 	assert.NotNil(f.New("Switch"))
 	assert.Nil(f.New("random"))
 }
@@ -49,7 +49,7 @@ func TestListMarshalUnmarshal(t *testing.T) {
 	assert := assert.New(t)
 
 	funMap := zebra.Factory()
-	funMap.Add("VLANPool", func() zebra.Resource { return new(network.VLANPool) })
+	funMap.Add(network.VLANPoolType())
 
 	resA := zebra.NewResourceList(funMap)
 	assert.NotNil(resA)
@@ -96,7 +96,7 @@ func TestErrorMarshalUnmarshal(t *testing.T) {
 	assert := assert.New(t)
 
 	funMap := zebra.Factory()
-	funMap.Add("VLANPool", func() zebra.Resource { return new(network.VLANPool) })
+	funMap.Add(network.VLANPoolType())
 	resList := zebra.NewResourceList(funMap)
 	assert.NotNil(resList.UnmarshalJSON(nil))
 	assert.NotNil(resList.UnmarshalJSON([]byte(`[{"id":"0100000001"}]`)))
@@ -138,7 +138,11 @@ func TestGetFactory(t *testing.T) {
 	assert := assert.New(t)
 
 	f := zebra.Factory()
-	f.Add("Switch", func() zebra.Resource { return new(network.Switch) })
+	f.Add(network.SwitchType())
+	assert.NotEmpty(f.Types())
+	aType, ok := f.Type("Switch")
+	assert.True(ok)
+	assert.NotNil(aType)
 
 	resA := zebra.NewResourceMap(f)
 	assert.NotNil(resA)
@@ -151,7 +155,7 @@ func TestAdd(t *testing.T) {
 	assert := assert.New(t)
 
 	funMap := zebra.Factory()
-	funMap.Add("Switch", func() zebra.Resource { return new(network.Switch) })
+	funMap.Add(network.SwitchType())
 
 	resA := zebra.NewResourceMap(funMap)
 	assert.NotNil(resA)
@@ -167,7 +171,7 @@ func TestDelete(t *testing.T) {
 	assert := assert.New(t)
 
 	funMap := zebra.Factory()
-	funMap.Add("Switch", func() zebra.Resource { return new(network.Switch) })
+	funMap.Add(network.SwitchType())
 
 	resA := zebra.NewResourceMap(funMap)
 	assert.NotNil(resA)
@@ -190,7 +194,7 @@ func TestMapMarshalUnMarshal(t *testing.T) {
 	assert := assert.New(t)
 
 	funMap := zebra.Factory()
-	funMap.Add("VLANPool", func() zebra.Resource { return new(network.VLANPool) })
+	funMap.Add(network.VLANPoolType())
 
 	resA := zebra.NewResourceMap(funMap)
 	assert.NotNil(resA)

--- a/store/store_test.go
+++ b/store/store_test.go
@@ -58,7 +58,7 @@ func TestClear(t *testing.T) {
 	t.Cleanup(func() { os.RemoveAll(root) })
 
 	factory := zebra.Factory()
-	factory.Add("VLANPool", func() zebra.Resource { return new(network.VLANPool) })
+	factory.Add(network.VLANPoolType())
 
 	rs := store.NewResourceStore(root, factory)
 	assert.NotNil(rs)
@@ -88,7 +88,7 @@ func TestLoad(t *testing.T) {
 	t.Cleanup(func() { os.RemoveAll(root) })
 
 	factory := zebra.Factory()
-	factory.Add("VLANPool", func() zebra.Resource { return new(network.VLANPool) })
+	factory.Add(network.VLANPoolType())
 
 	rs := store.NewResourceStore(root, factory)
 	assert.NotNil(rs)
@@ -121,7 +121,7 @@ func TestCreate(t *testing.T) {
 	t.Cleanup(func() { os.RemoveAll(root) })
 
 	factory := zebra.Factory()
-	factory.Add("VLANPool", func() zebra.Resource { return new(network.VLANPool) })
+	factory.Add(network.VLANPoolType())
 
 	rs := store.NewResourceStore(root, factory)
 	assert.NotNil(rs)
@@ -152,7 +152,7 @@ func TestDelete(t *testing.T) {
 	t.Cleanup(func() { os.RemoveAll(root) })
 
 	factory := zebra.Factory()
-	factory.Add("VLANPool", func() zebra.Resource { return new(network.VLANPool) })
+	factory.Add(network.VLANPoolType())
 
 	rs := store.NewResourceStore(root, factory)
 	assert.NotNil(rs)
@@ -186,7 +186,7 @@ func TestQuery(t *testing.T) {
 	t.Cleanup(func() { os.RemoveAll(root) })
 
 	factory := zebra.Factory()
-	factory.Add("VLANPool", func() zebra.Resource { return new(network.VLANPool) })
+	factory.Add(network.VLANPoolType())
 
 	rs := store.NewResourceStore(root, factory)
 	assert.NotNil(rs)
@@ -213,7 +213,7 @@ func TestQueryUUID(t *testing.T) {
 	t.Cleanup(func() { os.RemoveAll(root) })
 
 	factory := zebra.Factory()
-	factory.Add("VLANPool", func() zebra.Resource { return new(network.VLANPool) })
+	factory.Add(network.VLANPoolType())
 
 	rs := store.NewResourceStore(root, factory)
 	assert.NotNil(rs)
@@ -247,8 +247,8 @@ func TestQueryType(t *testing.T) {
 	t.Cleanup(func() { os.RemoveAll(root) })
 
 	factory := zebra.Factory()
-	factory.Add("VLANPool", func() zebra.Resource { return new(network.VLANPool) })
-	factory.Add("Lab", func() zebra.Resource { return new(dc.Lab) })
+	factory.Add(network.VLANPoolType())
+	factory.Add(dc.LabType())
 
 	rs := store.NewResourceStore(root, factory)
 	assert.NotNil(rs)
@@ -284,7 +284,7 @@ func TestQueryLabel(t *testing.T) {
 	t.Cleanup(func() { os.RemoveAll(root) })
 
 	factory := zebra.Factory()
-	factory.Add("VLANPool", func() zebra.Resource { return new(network.VLANPool) })
+	factory.Add(network.VLANPoolType())
 
 	rs := store.NewResourceStore(root, factory)
 	assert.NotNil(rs)
@@ -325,7 +325,7 @@ func TestQueryProperty(t *testing.T) {
 	res1, res2 := getVLAN(), getLab()
 
 	f := zebra.Factory()
-	f.Add("VLANPool", func() zebra.Resource { return new(network.VLANPool) })
+	f.Add(network.VLANPoolType())
 
 	rs := store.NewResourceStore(root, f)
 	assert.Nil(rs.Initialize())

--- a/store/types.go
+++ b/store/types.go
@@ -1,0 +1,36 @@
+package store
+
+import (
+	"github.com/project-safari/zebra"
+	"github.com/project-safari/zebra/auth"
+	"github.com/project-safari/zebra/compute"
+	"github.com/project-safari/zebra/dc"
+	"github.com/project-safari/zebra/network"
+)
+
+// DefaultFactory returns a resource factory with all the known types.
+func DefaultFactory() zebra.ResourceFactory {
+	factory := zebra.Factory()
+
+	// network resources
+	factory.Add(network.SwitchType())
+	factory.Add(network.IPAddressPoolType())
+	factory.Add(network.VLANPoolType())
+
+	// dc resources
+	factory.Add(dc.DataCenterType())
+	factory.Add(dc.LabType())
+	factory.Add(dc.RackType())
+
+	// compute resources
+	factory.Add(compute.ServerType())
+	factory.Add(compute.ESXType())
+	factory.Add(compute.VCenterType())
+	factory.Add(compute.VMType())
+
+	// zebra server resources
+	factory.Add(auth.UserType())
+
+	// Need to add all the known types here
+	return factory
+}

--- a/store/types_test.go
+++ b/store/types_test.go
@@ -1,0 +1,23 @@
+package store_test
+
+import (
+	"testing"
+
+	"github.com/project-safari/zebra/store"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestDefaultFactory(t *testing.T) {
+	t.Parallel()
+
+	assert := assert.New(t)
+	types := store.DefaultFactory()
+	assert.NotNil(types)
+
+	typeList := types.Types()
+	assert.NotEmpty(typeList)
+
+	for _, t := range typeList {
+		assert.NotNil(t.New())
+	}
+}


### PR DESCRIPTION
Fixes #66 

```
❯ echo '{"types": ["Server"]}' | http GET :9999/api/v1/types
HTTP/1.1 200 OK
Content-Length: 60
Content-Type: application/json
Date: Sun, 17 Jul 2022 03:37:51 GMT

{
    "types": [
        {
            "description": "compute server",
            "name": "Server"
        }
    ]
}
```

```
❯ http :9999/api/v1/types
HTTP/1.1 200 OK
Content-Length: 541
Content-Type: application/json
Date: Sun, 17 Jul 2022 03:38:54 GMT

{
    "types": [
        {
            "description": "compute server",
            "name": "Server"
        },
        {
            "description": "VMWare ESX server",
            "name": "ESX"
        },
        {
            "description": "virtual machine",
            "name": "VM"
        },
        {
            "description": "zebra user",
            "name": "User"
        },
        {
            "description": "network server",
            "name": "Switch"
        },
        {
            "description": "vlan pool",
            "name": "VLANPool"
        },
        {
            "description": "data center lab",
            "name": "Lab"
        },
        {
            "description": "VMWare vcenter",
            "name": "VCenter"
        },
        {
            "description": "ip address pool",
            "name": "IPAddressPool"
        },
        {
            "description": "data center",
            "name": "Datacenter"
        },
        {
            "description": "server rack",
            "name": "Rack"
        }
    ]
}